### PR TITLE
EF Core and AspNetCore.All version downgrade error

### DIFF
--- a/WebPushDemo/WebPushDemo.csproj
+++ b/WebPushDemo/WebPushDemo.csproj
@@ -16,7 +16,7 @@
 
 
     <PackageReference Include="Microsoft.AspNetCore.All" Version="2.0.9" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="2.0.1" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="2.0.3" />
     <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="2.0.2" />
     <PackageReference Include="WebPush" Version="1.0.10" />
   </ItemGroup>


### PR DESCRIPTION
Getting a version downgrade error after cloning and building the repository

seems Microsoft.EntityFrameworkCore.Tools - 2.0.1 doesn't like being in the same project which is targeting Microsoft.AspNetCore.All - 2.0.9

Updated EF Core Tools to 2.0.3 to remedy